### PR TITLE
Add more developer tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,6 @@ jobs:
         - build/makerelease.sh
         # wildcard copy to allow us to move versioning forward without updating travis
         - cp -v libarchive-*.tar.gz .versity/SOURCES/
-        - (cd .versity; docker build -t versity/libarchive-build .)
+        - (cd .versity; docker build -f Dockerfile.build -t versity/libarchive-build .)
         - (cd .versity; bash ./build_rpm_in_docker.sh)
+        - (cd .versity; docker build -f Dockerfile -t versity/python:2.7-libarchive .)

--- a/.versity/Dockerfile
+++ b/.versity/Dockerfile
@@ -1,14 +1,11 @@
-FROM centos:7
-
+FROM versity/python:2.7-devel
 MAINTAINER Nic Henke <nic.henke@versity.com>
 
-# Packages needed to build libarchive from source, including a few utilities to help with debugging
-RUN yum install -y epel-release && \
-    yum install -y which less bash gcc libattr libattr-devel libacl libacl-devel bzip2-devel \
-                   cmake bzip2 libz-devel openssl-devel libxml2 libxml2-devel xz-devel make \
-                   lz4 man man-pages gdb file automake libtool cscope ghostscript rsync \
-                   rpm-build bison sharutils lzo-devel e2fsprogs-devel lz4-devel && \
+# Install libarchive RPMs to docker container to allow python/cython bits a build environment
+COPY rpms/vsm-libarchive*.rpm /var/cache/
+
+# epel for lz4. We might be able to remove that requirement, I don't think we use it by default
+RUN yum install -y epel-release && yum makecache fast && \
+    yum install -y /var/cache/vsm-libarchive*.rpm && \
     yum clean all && \
     rm -fr ~/.cache && rm -fr /var/cache/*
-
-CMD ["/bin/bash"]

--- a/.versity/Dockerfile.build
+++ b/.versity/Dockerfile.build
@@ -1,0 +1,14 @@
+FROM centos:7
+
+MAINTAINER Nic Henke <nic.henke@versity.com>
+
+# Packages needed to build libarchive from source, including a few utilities to help with debugging
+RUN yum install -y epel-release && \
+    yum install -y which less bash gcc libattr libattr-devel libacl libacl-devel bzip2-devel \
+                   cmake bzip2 libz-devel openssl-devel libxml2 libxml2-devel xz-devel make \
+                   lz4 man man-pages gdb file automake libtool cscope ghostscript rsync \
+                   rpm-build bison sharutils lzo-devel e2fsprogs-devel lz4-devel && \
+    yum clean all && \
+    rm -fr ~/.cache && rm -fr /var/cache/*
+
+CMD ["/bin/bash"]

--- a/.versity/build_dist_gzip.sh
+++ b/.versity/build_dist_gzip.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -x
+set -e -o pipefail
+
+# just a subsection of makerelease.sh to speed things up for development
+pwd
+ls -al
+
+bash build/clean.sh
+export MAKE_LIBARCHIVE_RELEASE="1"
+/bin/sh build/autogen.sh
+
+./configure
+make dist-gzip

--- a/.versity/build_dist_gzip_in_docker.sh
+++ b/.versity/build_dist_gzip_in_docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -x
+set -e -o pipefail
+
+cd ..
+docker run -it --rm -v "$(pwd):/app" -w /app versity/libarchive-build /bin/bash /app/.versity/build_dist_gzip.sh

--- a/.versity/developer_build.sh
+++ b/.versity/developer_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Run all the steps a local developer needs to run. This generates RPMS and a docker container to
+# be used in building versity-python-libarchive.
+
+set -e -o pipefail
+set -x
+
+# NOTE: travis uses makerelease.sh, which is far more comprehensive. We are assuming the changes
+# have already been tested locally and the developer now wants to use those for RPM install or
+# Cython development and testing.
+
+rm -fv SOURCES/*.tar.gz
+bash build_dist_gzip_in_docker.sh
+cp -v ../libarchive-*.tar.gz SOURCES/
+
+docker build -f Dockerfile.build -t versity/libarchive-build .
+bash ./build_rpm_in_docker.sh
+docker build -f Dockerfile -t versity/python:2.7-libarchive .

--- a/README.versity
+++ b/README.versity
@@ -1,0 +1,37 @@
+# Travis CI
+ - https://travis-ci.org/versity/libarchive
+
+# Mac development environment
+This largely follow the .travis.yml and build/ci_build.sh. It is preferred to
+doing this on Mac natively vs docker and Linux, as docker doesn't allow the
+sparse tests to create files like it expects. We disable cpio for known failures, and we don't really care if it works :D
+
+Full test output in `Testing/Temporary/LastTest.log`
+
+    $ brew install xz lzop lz4 cmake
+    $ mkdir _mac_test
+    $ cd _mac_test
+    $ cmake -DENABLE_CPIO=OFF ..
+    $ make -j4
+    $ make test
+
+It isn't unusual for a few tests to fail. Pushing changes to Travis for testing will re-test those and if there are still failures, it is a problem.
+
+
+	The following tests FAILED:
+
+	346 - libarchive_test_read_format_zip_winzip_aes128 (Failed)
+	347 - libarchive_test_read_format_zip_winzip_aes256 (Failed)
+	349 - libarchive_test_read_format_zip_winzip_aes256_large (Failed)
+	476 - libarchive_test_write_format_zip_winzip_aes128_encryption (Failed)
+	477 - libarchive_test_write_format_zip_winzip_aes256_encryption (Failed)
+	
+## Building Developer artifacts
+This script wraps the sub items below, building a clean set of artifacts for the normal development process (dist tar.gz, RPMS, docker container).
+
+	$ cd .versity
+	$ bash developer_build.sh
+	
+
+# Links
+ * https://github.com/libarchive/libarchive/wiki/LibarchiveAddingTest


### PR DESCRIPTION
Now that we want to ship a Cython module from versity-python-libarchive,
we need a build environment. Our choice is always docker, as that allows
Mac hosts to play nicely and keeps the environments canned.

While here, update our script tools to make life nicer for the
developer. We now support the ability to make libarchive code changes
and have those built as RPMS and used for Python development.