### PR TITLE
Drop lz4 support in Versity RPMs

### DIFF
--- a/.versity/Dockerfile
+++ b/.versity/Dockerfile
@@ -4,8 +4,6 @@ MAINTAINER Nic Henke <nic.henke@versity.com>
 # Install libarchive RPMs to docker container to allow python/cython bits a build environment
 COPY rpms/vsm-libarchive*.rpm /var/cache/
 
-# epel for lz4. We might be able to remove that requirement, I don't think we use it by default
-RUN yum install -y epel-release && yum makecache fast && \
-    yum install -y /var/cache/vsm-libarchive*.rpm && \
+RUN yum install -y /var/cache/vsm-libarchive*.rpm && \
     yum clean all && \
     rm -fr ~/.cache && rm -fr /var/cache/*

--- a/.versity/Dockerfile.build
+++ b/.versity/Dockerfile.build
@@ -6,8 +6,8 @@ MAINTAINER Nic Henke <nic.henke@versity.com>
 RUN yum install -y epel-release && \
     yum install -y which less bash gcc libattr libattr-devel libacl libacl-devel bzip2-devel \
                    cmake bzip2 libz-devel openssl-devel libxml2 libxml2-devel xz-devel make \
-                   lz4 man man-pages gdb file automake libtool cscope ghostscript rsync \
-                   rpm-build bison sharutils lzo-devel e2fsprogs-devel lz4-devel && \
+                   man man-pages gdb file automake libtool cscope ghostscript rsync \
+                   rpm-build bison sharutils lzo-devel e2fsprogs-devel && \
     yum clean all && \
     rm -fr ~/.cache && rm -fr /var/cache/*
 

--- a/.versity/libarchive.spec
+++ b/.versity/libarchive.spec
@@ -26,7 +26,6 @@ BuildRequires:  libacl-devel
 BuildRequires:  libattr-devel
 BuildRequires:  openssl-devel
 BuildRequires:  libxml2-devel
-BuildRequires:  lz4-devel
 BuildRequires:  automake
 
 


### PR DESCRIPTION
lz4 comes from epel, a repository that we avoid for customer facing
installations. We don't use the lz4 functionality for our pax/tar
interfaces, so we'll remove and make the dependency tree smaller and
simpler.