### PR TITLE
Deploy RPMs to artifactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,20 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
+
 before_install:
   - if [ `uname` = "Darwin" ]; then brew update; fi
+  - if [ `uname` = "Darwin" ]; then wget https://dl.bintray.com/jfrog/jfrog-cli-go/1.14.0/jfrog-cli-mac-386/jfrog; fi
+  - if [ `uname` = "Linux" ]; then wget https://dl.bintray.com/jfrog/jfrog-cli-go/1.14.0/jfrog-cli-linux-amd64/jfrog; fi
+
+  - env | sort
+
+  - chmod +x ./jfrog
+  - ./jfrog rt config versity --url "$ARTIFACTORY_URL" --user "$ARTIFACTORY_USER" --password "$ARTIFACTORY_PASSWORD"
+
 install:
   - if [ `uname` = "Darwin" ]; then brew install xz lzop lz4; fi
+
 script:
   - build/ci_build.sh
 
@@ -44,7 +54,16 @@ jobs:
       script:
         - build/makerelease.sh
         # wildcard copy to allow us to move versioning forward without updating travis
+        # NOTE: we run these here to verify a release is ready. the deploy step will run
+        # again, instead of us copying the artifacts around S3
         - cp -v libarchive-*.tar.gz .versity/SOURCES/
         - (cd .versity; docker build -f Dockerfile.build -t versity/libarchive-build .)
         - (cd .versity; bash ./build_rpm_in_docker.sh)
         - (cd .versity; docker build -f Dockerfile -t versity/python:2.7-libarchive .)
+    - stage: deploy
+      if: tag IS present and branch IS present
+      os: linux
+      compiler: gcc
+      env: BUILD_SYSTEM=cmake
+      provider: script
+      script: /bin/bash -x $TRAVIS_BUILD_DIR/.versity/travis_deploy.sh

--- a/.versity/developer_build.sh
+++ b/.versity/developer_build.sh
@@ -9,11 +9,11 @@ set -x
 # NOTE: travis uses makerelease.sh, which is far more comprehensive. We are assuming the changes
 # have already been tested locally and the developer now wants to use those for RPM install or
 # Cython development and testing.
+docker build -f Dockerfile.build -t versity/libarchive-build .
 
 rm -fv SOURCES/*.tar.gz
 bash build_dist_gzip_in_docker.sh
 cp -v ../libarchive-*.tar.gz SOURCES/
 
-docker build -f Dockerfile.build -t versity/libarchive-build .
 bash ./build_rpm_in_docker.sh
 docker build -f Dockerfile -t versity/python:2.7-libarchive .

--- a/.versity/travis_deploy.sh
+++ b/.versity/travis_deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -x
+
+DOT_VERSITY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$DOT_VERSITY"
+pwd
+env | sort
+
+# Build release artifacts and upload to our artifactory repo
+
+bash ./developer_build.sh
+
+ls -la rpms/*.rpm
+
+# We upload the same set of RPMs to both el7 repos for now, to make it easier to install until we
+# refactor the repo... provided we can comingle kmod RPMs.
+PATTERN="rpms/*.rpm"
+
+for el_version in "7.4.1708" "7.3.1611"; do
+    repo="public-rpms/${el_version}/"
+    "$TRAVIS_BUILD_DIR"/jfrog rt upload "${PATTERN}" "${repo}"
+done


### PR DESCRIPTION
Now that we have RPMs, we should ship those for users. This builds on
top of our Artifactory repo structure and uploads the resulting
vsm-libarchive RPMs and friends.