### PR TITLE
Clear PAX KW on entry cleanup

### DIFF
--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -167,6 +167,7 @@ archive_entry_clear(struct archive_entry *entry)
 	archive_acl_clear(&entry->acl);
 	archive_entry_xattr_clear(entry);
 	archive_entry_sparse_clear(entry);
+	archive_entry_pax_kw_clear(entry);
 	free(entry->stat);
 	memset(entry, 0, sizeof(*entry));
 	return entry;


### PR DESCRIPTION
There was a lingering memory leak for the archive entries that had PAX
keywords parsed into them. We were missing the partner clear in
archive_entry_clear like the other handlers (sparse, xattr, acl).

This was found with valgrind on the versity-python-libarchive test
suite.