### PR TITLE
Bump versity release version

### DIFF
--- a/.versity/libarchive.spec
+++ b/.versity/libarchive.spec
@@ -4,7 +4,7 @@
 
 Name:           vsm-libarchive
 Version:        3.3.2vsm
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A library for handling streaming archive formats
 
 License:        BSD


### PR DESCRIPTION
We need a new RPM version so that RPMs are updated on systems. This will
help them get the new memory leak fixes in the normal course of an
install.